### PR TITLE
[Emergecny Bug Fix] ContentManager mintbatch bug

### DIFF
--- a/src/contents.ts
+++ b/src/contents.ts
@@ -224,7 +224,11 @@ export function handleMint(event: MintEvent): void {
   receiver.transactionsCount = receiver.transactionsCount.plus(ONE_BI);
   receiver.save();
 
-  let operator = Account.load(event.params.operator.toHexString())!;
+  let operator = Account.load(event.params.operator.toHexString());
+  if (operator == null) {
+    // Add new operator
+    operator = createAccount(event.params.operator);
+  }
   operator.transactionsAsOperatorCount = operator.transactionsAsOperatorCount.plus(ONE_BI);
   operator.save();
 


### PR DESCRIPTION
Content Manager had a left over MintBatch() function so it can mint assets. However, the subgraph expects that only only the Content contract can mint. This means that if the content manager mints an asset, the ContentManager contract address is the 'operator'. However, the subgraph never created an account object for the ContentManager. This causes a fatal error. The temporary fix here is to create an Account if it doesn't exist yet. 