### PR TITLE
Add amount claimed in the order entity

### DIFF
--- a/exchange.graphql
+++ b/exchange.graphql
@@ -56,6 +56,7 @@ type Order @entity {
   price: BigInt!
   amountOrdered: BigInt!
   amountFilled: BigInt!
+  amountClaimed: BigInt!
   status: OrderStatus!
   createdAtTimestamp: BigInt!
   filledAtTimestamp: BigInt!
@@ -75,8 +76,8 @@ type OrderFill @entity {
 }
 
 enum OrderType {
-    Buy
-    Sell
+  Buy
+  Sell
 }
 
 enum OrderStatus {

--- a/src/exchange-helpers.ts
+++ b/src/exchange-helpers.ts
@@ -53,6 +53,7 @@ export function createOrder(id: BigInt, assetId: string, owner: string, exchange
     order.owner = owner;
     order.amountOrdered = ZERO_BI;
     order.amountFilled = ZERO_BI;
+    order.amountClaimed = ZERO_BI;
     order.status = "Ready";
     order.price = ZERO_BI;
     order.createdAtTimestamp = ZERO_BI;

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -216,6 +216,7 @@ export function handleOrdersDeleted(event: OrdersDeletedEvent): void {
         let order = Order.load(orderId.toHexString())!;
         order.status = "Cancelled";
         order.cancelledAtTimestamp = event.block.timestamp;
+        order.amountClaimed = order.amountFilled;
         order.save();
         
         let orderOwner = Account.load(order.owner)!;
@@ -246,6 +247,7 @@ export function handleOrdersClaimed(event: OrdersClaimedEvent): void {
 
         // Update lastClaimedAtTimestamp every time (even for partially filled orders)
         order.lastClaimedAtTimestamp = event.block.timestamp;
+        order.amountClaimed = order.amountFilled;
         order.save();
     }
 }


### PR DESCRIPTION
Adding AmountClaimed in the order entity in the subgraph so that the front end can:
- calculate how much is claimable (assets and tokens)
- filter for claimable orders
- determine if the order can be partially claimed after being partially filled
- determine if a cancelled order was partially claimable